### PR TITLE
Improving user experience of search responses

### DIFF
--- a/config/mtg.yaml
+++ b/config/mtg.yaml
@@ -8,3 +8,6 @@ collections:
   - provider: moxfield
     discord_user: .sparky
     provider_collection: PUYRTn5Q2kqiBB531_1W1Q
+  - provider: moxfield
+    discord_user: makimakiroll
+    provider_collection: b7fNJ-tWrkKN-abuIN2IgA

--- a/src/mtg/models.rs
+++ b/src/mtg/models.rs
@@ -1,9 +1,21 @@
 pub const CARD_NAME_MAX_LEN: u16 = 128;
-pub const DISCORD_EMBED_FIELD_MAX_LEN: usize = 1024;
+pub const EMBED_DESCRIPTION_MAX_LEN: u16 = 4096;
 
 // collection search result model
 pub struct SearchResultCard {
     pub name: String,
+    pub set: String,
+    pub cn: String,
     pub quantity: i64,
     pub owner: String,
+}
+
+// embed model
+pub struct SearchResultEmbed {
+    pub title: String,
+    pub name: String,
+    pub set: String,
+    pub cn: String,
+    pub owners: Vec<String>,
+    pub quantities: Vec<String>,
 }

--- a/src/mtg/providers/archidekt.rs
+++ b/src/mtg/providers/archidekt.rs
@@ -8,7 +8,10 @@ use crate::mtg::models::SearchResultCard;
 #[derive(Deserialize)]
 struct ArchidektCard {
     name: String,
+    set: String,
+    cn: String,
 }
+    
 
 #[derive(Deserialize)]
 struct ArchidektSearchResult {
@@ -24,7 +27,7 @@ struct ArchidektSearchResponse {
 pub async fn search(discord_user: &String, collection_id: &String, search_term: &String) -> Result<Vec<SearchResultCard>, Box<dyn Error>> {
     let client = Client::new();
 
-    log::info!("Searching library of collection id {} for term {}",collection_id,search_term);
+    log::info!("Searching archidekt collection of '{}' with collection id '{}' for term '{}'",discord_user,collection_id,search_term);
     let resp = client
         .get(format!("https://www.archidekt.com/api/collection/{}/?cardName={}", collection_id, urlencoding::encode(search_term)))
         .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
@@ -44,6 +47,8 @@ pub async fn search(discord_user: &String, collection_id: &String, search_term: 
     for result in archidekt_response.results {
         result_cards.push(SearchResultCard {
             name: result.card.name,
+            set: result.card.set,
+            cn: result.card.cn,
             quantity: result.quantity,
             owner: discord_user.clone(),
         })

--- a/src/mtg/providers/moxfield.rs
+++ b/src/mtg/providers/moxfield.rs
@@ -10,6 +10,8 @@ use crate::mtg::models::SearchResultCard;
 #[derive(Deserialize)]
 struct MoxfieldCard {
     name: String,
+    set: String,
+    cn: String,
 }
 
 #[derive(Deserialize)]
@@ -27,7 +29,7 @@ pub async fn search(discord_user: &String, collection_id: &String, search_term: 
     let client = Client::new();
     let modified_search_term = format!("\"{}\"",search_term);
 
-    log::info!("Searching library of collection id {} for term {}",collection_id,search_term);
+    log::info!("Searching moxfield collection of '{}' with collection id '{}' for term '{}'",discord_user,collection_id,search_term);
     let resp = client
         .get(format!("https://api2.moxfield.com/v1/trade-binders/{}/search?q={}", collection_id, &modified_search_term))
         .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
@@ -47,6 +49,8 @@ pub async fn search(discord_user: &String, collection_id: &String, search_term: 
     for result in moxfield_response.data {
         result_cards.push(SearchResultCard {
             name: result.card.name,
+            set: result.card.set,
+            cn: result.card.cn,
             quantity: result.quantity,
             owner: discord_user.clone(),
         })


### PR DESCRIPTION
adds...

- cards are now grouped by set / cn
- results with less than 10 show embeds with image and link to scryfall
- results with more than 10 show compact form in a single embed with no image and link to scryfall
- results with more than the embed limit in compact mode have a `truncated` warning