### PR TITLE
Fix archidekt spacing issue

### DIFF
--- a/src/mtg/providers/archidekt.rs
+++ b/src/mtg/providers/archidekt.rs
@@ -1,5 +1,4 @@
-use reqwest::{StatusCode,Client};
-use reqwest::header::CONTENT_TYPE;
+use reqwest::{Client, StatusCode};
 use std::error::Error;
 use serde::Deserialize;
 use crate::mtg::models::{SearchResultCard, CommunityDeckMetadata};
@@ -49,10 +48,9 @@ struct ArchidektSearchResponse {
 pub async fn search(discord_user: String, collection_id: String, search_term: String) -> Result<Vec<SearchResultCard>, Box<dyn Error + Send + Sync>> {
     let client = Client::new();
 
-    log::info!("Searching archidekt collection of '{}' with collection id '{}' for term '{}'",discord_user,collection_id,search_term);
     let resp = client
-        .get(format!("https://www.archidekt.com/api/collection/{}/?cardName={}", collection_id, urlencoding::encode(&search_term)))
-        .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .get(format!("https://archidekt.com/api/collection/{}/", collection_id))
+        .query(&[("cardName", search_term)])
         .send()
         .await?;
 

--- a/src/mtg/providers/archidekt.rs
+++ b/src/mtg/providers/archidekt.rs
@@ -48,6 +48,7 @@ struct ArchidektSearchResponse {
 pub async fn search(discord_user: String, collection_id: String, search_term: String) -> Result<Vec<SearchResultCard>, Box<dyn Error + Send + Sync>> {
     let client = Client::new();
 
+    log::info!("Searching archidekt collection of '{}' with collection id '{}' for term '{}'",discord_user,collection_id,search_term);
     let resp = client
         .get(format!("https://archidekt.com/api/collection/{}/", collection_id))
         .query(&[("cardName", search_term)])


### PR DESCRIPTION
Fixing an issue with archidekt spacing not working properly. spaces were getting double-encoded, while reqwests typically handles encoding automatically